### PR TITLE
fix(payload): #25 preserve title and other state properties in updateState calls

### DIFF
--- a/apps/payload/src/outpost/state/useOutpostState.ts
+++ b/apps/payload/src/outpost/state/useOutpostState.ts
@@ -239,6 +239,7 @@ export const useOutpostState = () => {
   const removeContract = (id: number) => {
     const contractToRemoveMessagesIds = getContract(id)?.messages;
     updateState({
+      ...state[state.current],
       messages: state[state.current].messages.filter(
         item => contractToRemoveMessagesIds?.indexOf(item.id) === -1,
       ),
@@ -255,6 +256,7 @@ export const useOutpostState = () => {
     const updated = getContract(newItem.contractId);
     if (!updated) return;
     updateState({
+      ...state[state.current],
       contracts: [
         ...state[state.current].contracts.filter(
           item => item.id !== newItem.contractId,
@@ -304,6 +306,7 @@ export const useOutpostState = () => {
 
     if (!updated) return;
     updateState({
+      ...state[state.current],
       contracts: [
         ...state[state.current].contracts.filter(
           item => item.id !== updated.id,


### PR DESCRIPTION
## Hey, I just made a Pull Request!

Fix #25: `addMessage`, `removeContract`, and `removeMessage` in `useOutpostState` were passing incomplete objects to `updateState()`, causing title and other properties (version, params, isReadonly) to be silently dropped. Added `...state[state.current]` spread to match the pattern already used by `addContract` and `updateContract`.


<!-- Please describe what you added, and add a screenshot if possible.
     That makes it easier to understand the change so we can :shipit: faster. -->

#### :heavy_check_mark: Checklist

<!--- Please include the following in your Pull Request when applicable: -->

- [ ] Added or updated documentation
- [ ] Tests for new functionality and regression tests for bug fixes
- [ ] Screenshots attached (for UI changes)